### PR TITLE
13 internal config leaks

### DIFF
--- a/custom-acl.d.ts
+++ b/custom-acl.d.ts
@@ -6,14 +6,14 @@ export declare class AclNode {
   private #children: AclNode[];
   private #merge: ((config: Record<string, any>, newConfig: Record<string, any>) => void) | null;
   private #diff: ((config: Record<string, any>, newConfig: Record<string, any>) => Record<string, any>) | null;
-  private #onUpdate: () => void;
+  private #onUpdate: (config) => void;
 
   constructor(options: {
     config?: Record<string, any>;
     name?: string;
     merge?: (config: Record<string, any>, newConfig: Record<string, any>) => void;
     diff?: (config: Record<string, any>, newConfig: Record<string, any>) => Record<string, any>;
-    onUpdate?: () => void;
+    onUpdate?: (config) => void;
   });
 
   setParent(node: AclNode): void;

--- a/lib/acl-node.js
+++ b/lib/acl-node.js
@@ -61,7 +61,7 @@ module.exports = class AclNode {
     else this.#config = cfg
     this.recalcDot()
     this.updateChilderen(cfg)
-    if (this.#onUpdate) this.#onUpdate(this.#config)
+    if (this.#onUpdate) this.#onUpdate(this.config)
   }
 
   get dotColor () {


### PR DESCRIPTION
Now returns copy of config.
Additionaly fix problem where `config` not being mentioned in types.